### PR TITLE
Fix suit-condition-dependency-integrity in CDDL

### DIFF
--- a/draft-ietf-suit-trust-domains.cddl
+++ b/draft-ietf-suit-trust-domains.cddl
@@ -33,7 +33,7 @@ SUIT_Dependency_Metadata = {
     * $$SUIT_Dependency_Extensions
 }
 
-SUIT_Condition // (
+SUIT_Condition //= (
     suit-condition-dependency-integrity, SUIT_Rep_Policy)
 SUIT_Condition //= (
     suit-condition-is-dependency, SUIT_Rep_Policy)


### PR DESCRIPTION
Fixing a bug in the cddl file, introduced by me in this commit 6714e2d .
Forgive me.