### PR TITLE
Fix IANA Considerations reflecting comment

### DIFF
--- a/draft-ietf-suit-trust-domains.md
+++ b/draft-ietf-suit-trust-domains.md
@@ -516,7 +516,7 @@ When some Components are "installed" or "loaded" it is more productive to use li
 
 #  IANA Considerations {#iana}
 
-IANA is requested to allocate the following numbers in the listed registries:
+IANA is requested to allocate the following numbers in the listed registries created by draft-ietf-suit-manifest:
 
 ## SUIT Envelope Elements
 


### PR DESCRIPTION
> We would ordinarily recommend listing requested values as "suggested" if the registry had already been created.

Not done.